### PR TITLE
change weak id to use the code from within the image URL

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -80,10 +80,9 @@ def scrape_senate_page(url, page_number, honorifics)
       raw_name = tds[2].text.tidy
       name, honorific = split_honorific_and_name(raw_name, honorifics)
       image_url = tds[1].xpath('./img/@src').text.tidy
-      # TODO @tmtmtm suggests using
-      # TODO something like image[/(\d+).JPG/, 1] for id
+      id_from_image = image_url.match(/(\d+_?\d+)\.JPG/i)[1]
       data = { 
-        id: senate_id,
+        id: id_from_image,
         name: name,
         image: image_url,
         honorific_prefix: honorific,


### PR DESCRIPTION
So far this appears to be robust (every entry does have a photo) but
I've decided to let it blow up (that is, no rescue) if an ID can't be
found in the image URL. If that happens, it seems like the scraper
should fail because it will need rewriting to handle this situation
(most likely case perhaps is someone being added without a photo).

Don't know why a handful of images have the DDDD_DDDD format; couldn't
spot a useful pattern and if the pictures don't change much it doesn't
really matter -- so this takes the DDDD_DDDD rather than trying to guess
which DDDD is best to use.
